### PR TITLE
Add Gitpod settings for pytest

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,3 +3,7 @@ image:
 
 tasks:
   - init: pip install -r ./requirements.txt
+vscode:
+  extensions:
+    - littlefoxteam.vscode-python-test-adapter@0.6.5:M/0xh/MNGJTptXts7fD1Ug==
+    - hbenl.vscode-test-explorer@2.19.5:yg+hg6b1O51L7NliE9pc5Q==

--- a/.theia/settings.json
+++ b/.theia/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.autoSave": "on"
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = tests.py test_*.py *_tests.py


### PR DESCRIPTION
These settings files activates the Python Test Explorer extension for Gitpod.